### PR TITLE
Fix delete old release logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,9 +92,12 @@ async function deleteOlderReleases(keepLatest) {
     console.log(
       `💬  found total of ${activeMatchedReleases.length}${matchingLoggingAddition} active release(s)`
     );
+
     releaseIdsAndTags = activeMatchedReleases
+      .sort((a,b)=> Date.parse(b.published_at) - Date.parse(a.published_at))
       .map(({ id, tag_name: tagName }) => ({ id, tagName }))
       .slice(keepLatest);
+
   } catch (error) {
     console.error(`🌶  failed to get list of releases <- ${error.message}`);
     console.error(`exiting...`);


### PR DESCRIPTION
Fix #14 
Sort in reverse order by release date, and delete the oldest release, instead of simply deleting the last item in the list.
Works better with keep_latest