### PR TITLE
feat: add download quantity removal rules and handle more than 100 releases per time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ This action deletes older releases of given repo
 Add following step to your workflow:
 
 ```yaml
-- uses: dev-drprasad/delete-older-releases@v0.2
+- uses: dev-drprasad/delete-older-releases@master
   with:
     repo: <owner>/<repoName> # defaults to current repo
     keep_latest: 3
+    keep_min_download_counts: 1 # Optional parameters
+    delete_expired_data: 10 # Optional parameters
     delete_tag_pattern: beta # defaults to ""
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -23,6 +25,22 @@ Add following step to your workflow:
 | true     |
 
 Specifies number of latest releases (sorted by `created_at`) to keep. Pass `0` if you want to delete all releases
+
+#### `keep_min_download_counts`
+
+| required | default |
+| -------- | ------- |
+| false    |    0    |
+
+Specifies that versions with fewer downloads than this value (sorted by "created_at") are to be removed. If you do not need this restriction, please pass "0" or do not set the variable. The rule is less than, not less than or equal to, and values greater than or equal to will be retained.
+
+#### `delete_expired_data`
+
+| required | default |
+| -------- | ------- |
+| false    |    0    |
+
+To delete data that exceeds the specified number of days, please enter the number of overdue days. For example, setting the value to 10 will delete release data created more than 10 days ago. Note that this parameter is based on keep latest.
 
 #### `delete_tags`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This action deletes older releases of given repo
 Add following step to your workflow:
 
 ```yaml
-- uses: dev-drprasad/delete-older-releases@master
+- uses: dev-drprasad/delete-older-releases@v0.3.0
   with:
     repo: <owner>/<repoName> # defaults to current repo
     keep_latest: 3

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Specifies number of latest releases (sorted by `created_at`) to keep. Pass `0` i
 | -------- | ------- |
 | false    |    0    |
 
-Specifies that versions with fewer downloads than this value (sorted by "created_at") are to be removed. If you do not need this restriction, please pass "0" or do not set the variable. The rule is less than, not less than or equal to, and values greater than or equal to will be retained.
+Specifies the number of downloads that versions must have at minimum, otherwise they will be removed ....
 
 #### `delete_expired_data`
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: 0
   delete_expired_data:
-    description: Delete data older than a specified number of days
+    description: Delete releases older than a specified number of days
     required: false
     default: 0
   repo:

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,14 @@ inputs:
   keep_latest:
     description: how many latest releases to keep
     required: true
+  keep_min_download_counts:
+    description: keep old releases with downloads greater than this parameter <
+    required: false
+    default: 0
+  delete_expired_data:
+    description: Delete data older than a specified number of days
+    required: false
+    default: 0
   repo:
     description: repo name in the form of <owner>/<repoName>
     required: false


### PR DESCRIPTION
Fixed #17
Fixed #18 

The test is fine，I have been busy and haven't had the time to do it. I'm really sorry. 
The update content is as follows:
1. Add logic to obtain all releases. Due to Github API limitations, it seems that 1,000 releases can be obtained.
2. Add the download volume parameter (optional parameter). You can delete releases that are less than the download volume according to the set download volume.
3. Add the release parameter that deletes more than the number of days (optional parameter)

The specific logic is as follows：

![image](https://github.com/dev-drprasad/delete-older-releases/assets/6050360/5b6855cf-8ad6-4df6-a862-7d795a466d73)


![image](https://github.com/dev-drprasad/delete-older-releases/assets/6050360/b928a01f-e050-4904-8a21-b34e206ee8ee)


