### PR TITLE
fix: path contains unescaped characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ async function deleteOlderReleases(keepLatest, keepMinDownloadCount, deleteExpir
         try {
           const _ = await fetch({
             ...commonOpts,
-            path: `/repos/${owner}/${repo}/git/refs/tags/${tagName}`,
+            path: `/repos/${owner}/${repo}/git/refs/tags/${encodeURI(tagName)}`,
             method: "DELETE",
           });
         } catch (error) {


### PR DESCRIPTION
When the tagName parameter contains such as Chinese characters, an error occurs: `Request path contains unescaped characters.`