### PR TITLE
fix: remove has assets condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,11 @@ flowchart TD
 02[Get github all releases]
 03[Filter pre-release data]
 04[Filter delete_tag_pattern]
-05[Filter assets length > 0]
-06[Sort data by date]
-07[Filter keep latest]
-08[Filter keep keepMinDownloadCount]
-09[Filter deleteExpiredData]
-10[Delete old release and tag]
+05[Sort data by date]
+06[Filter keep latest]
+07[Filter keep keepMinDownloadCount]
+08[Filter deleteExpiredData]
+09[Delete old release and tag]
 
     01 --> 02
     02 -.-> 03
@@ -103,9 +102,8 @@ flowchart TD
     03 --> 05
     04 --> 05
     05 --> 06
-    06 --> 07
-    07 -.-> 08
-    07 -.-> 09
-    09 --> 10
-    08 --> 10
+    06 -.-> 07
+    06 -.-> 08
+    07 --> 09
+    08 --> 09
 ```

--- a/index.js
+++ b/index.js
@@ -126,15 +126,15 @@ async function deleteOlderReleases(keepLatest, keepMinDownloadCount, deleteExpir
     const activeMatchedReleases = data.filter((item) => {
       if (deletePrereleaseOnly) {
         if (deletePatternStr) {
-          return !item.draft && item.assets.length > 0 && item.prerelease && item.tag_name.match(deletePattern);
+          return !item.draft && item.prerelease && item.tag_name.match(deletePattern);
         } else {
-          return !item.draft && item.assets.length > 0 && item.prerelease;
+          return !item.draft && item.prerelease;
         }
       } else {
         if (deletePatternStr) {
-          return !item.draft && item.assets.length > 0 && item.tag_name.match(deletePattern);
+          return !item.draft && item.tag_name.match(deletePattern);
         } else {
-          return !item.draft && item.assets.length > 0;
+          return !item.draft;
         }
       }
     })


### PR DESCRIPTION
- Fixes #46
- Fixes #44 
- Fixes #42 

I don't think this is a bug in GitHub's API, but was perhaps a bug before. zipball and tarball "assets" are in a separate key as you can see [here](https://api.github.com/repos/ReenigneArcher/lb-release-testing/releases/156392941), and probably should have never been listed under "assets".

I also don't see a valid reason why you would use "assets" count to verify if it's a release or not. You already know it's a release because it's in the releases api.

P.S. It's unfortunate, but I'm pretty sure no one from GitHub will ever read anything in their community discussions: https://github.com/orgs/community/discussions/116306